### PR TITLE
fix: configure tesseract logger

### DIFF
--- a/lib/holeriteParser.ts
+++ b/lib/holeriteParser.ts
@@ -27,11 +27,13 @@ async function pdfToImages(buffer: Buffer): Promise<Buffer[]> {
 export async function ocrWithTesseract(buffer: Buffer): Promise<string> {
   const pre = await preprocessForOCR(buffer);
 
-  const worker = await Tesseract.createWorker({
-    logger: m => {
+  // Logger global (compatível com as tipagens atuais)
+  if (process.env.NODE_ENV !== 'production') {
+    Tesseract.setLogger(m => {
       // console.debug('[tesseract]', m);
-    },
-  });
+    });
+  }
+  const worker = await Tesseract.createWorker();
 
   try {
     await worker.loadLanguage('por+eng');


### PR DESCRIPTION
## Summary
- configure Tesseract logging via setLogger instead of createWorker options
- keep page segmentation mode through setParameters

## Testing
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f720a5b0832ca491e0195e93d1be