### PR TITLE
feat: add holerite import preview flow

### DIFF
--- a/app/api/holerites/import/route.ts
+++ b/app/api/holerites/import/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { extractTextFromPdfBuffer } from '@/lib/holeriteParser';
+import { extractFields } from '@/lib/importHolerites';
+import { HoleriteRow } from '@/types/holerite';
+
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  const files = formData.getAll('files');
+  const userEmail = formData.get('user_email') as string | null;
+
+  const previews: any[] = [];
+
+  for (const file of files) {
+    if (!(file instanceof File)) continue;
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    try {
+      const text = await extractTextFromPdfBuffer(buffer);
+      const row: HoleriteRow = extractFields(text, { userEmail: userEmail || undefined, fonte: file.name });
+      const extracted: Record<string, string> = {};
+      Object.entries(row).forEach(([k,v]) => {
+        extracted[k] = typeof v === 'number' ? String(v) : (v || '');
+      });
+      previews.push({ extracted, filename: file.name });
+    } catch (err:any) {
+      previews.push({ error: err.message, filename: file.name });
+    }
+  }
+
+  return NextResponse.json(previews);
+}

--- a/app/api/holerites/save/route.ts
+++ b/app/api/holerites/save/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { getRows, addRow } from '@/lib/googleSheetService';
+import { normalizeCurrency, normalizeDate } from '@/lib/holeriteParser';
+
+const SHEET_TITLE = 'Holerite';
+
+const numFields = ['salario_base','comissao','dsr','valor_bruto','valor_liquido','total_proventos','total_descontos','base_inss','base_fgts','base_irrf','fgts_mes'];
+
+export async function POST(req: Request) {
+  const draft = await req.json();
+  const row: any = {};
+  for (const [k,v] of Object.entries(draft)) {
+    if (numFields.includes(k)) row[k] = normalizeCurrency(v as string);
+    else if (k === 'data_pagamento') row[k] = normalizeDate(v as string);
+    else row[k] = v || '';
+  }
+
+  const rows = await getRows(SHEET_TITLE);
+  let existing = rows.find(r =>
+    r.get('cnpj_empresa') === row.cnpj_empresa &&
+    r.get('cpf_colaborador') === row.cpf_colaborador &&
+    r.get('mes') === row.mes &&
+    r.get('fonte_arquivo') === row.fonte_arquivo
+  );
+
+  let action: 'inserted' | 'updated' = 'inserted';
+  if (existing) {
+    Object.keys(row).forEach(key => {
+      (existing as any)[key] = row[key];
+    });
+    await existing.save();
+    action = 'updated';
+  } else {
+    await addRow(SHEET_TITLE, row);
+  }
+
+  return NextResponse.json({ ok: true, id_holerite: row.id_holerite, action });
+}

--- a/components/HoleriteReviewDialog.tsx
+++ b/components/HoleriteReviewDialog.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+export type Candidate = string | number;
+export type Rubrica = { codigo?: string; descricao: string; quantidade?: string; valor_provento?: string; valor_desconto?: string };
+export type HoleriteDraft = {
+  id_holerite?: string;
+  mes?: string; competencia?: string; empresa?: string; cnpj_empresa?: string;
+  colaborador?: string; cpf_colaborador?: string; matricula?: string; cargo?: string; departamento?: string;
+  salario_base?: string; comissao?: string; dsr?: string; dias_dsr?: string;
+  valor_bruto?: string; valor_liquido?: string; data_pagamento?: string; user_email?: string;
+  fonte_arquivo?: string; holerite_id?: string; rubricas_json?: string; status_validacao?: string;
+  total_proventos?: string; total_descontos?: string; base_inss?: string; base_fgts?: string; base_irrf?: string; fgts_mes?: string;
+};
+export type CandidatesMap = Partial<Record<keyof HoleriteDraft, Candidate[]>>;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  itemIndex: number;
+  totalItems: number;
+  pdfFile?: File;
+  extracted: HoleriteDraft;
+  candidates?: CandidatesMap;
+  onSave: (finalData: HoleriteDraft) => Promise<void>;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+const FIELDS: { key: keyof HoleriteDraft; label: string; textarea?: boolean }[] = [
+  { key: 'id_holerite', label: 'id_holerite' },
+  { key: 'mes', label: 'mes' },
+  { key: 'competencia', label: 'competencia' },
+  { key: 'empresa', label: 'empresa' },
+  { key: 'cnpj_empresa', label: 'cnpj_empresa' },
+  { key: 'colaborador', label: 'colaborador' },
+  { key: 'cpf_colaborador', label: 'cpf_colaborador' },
+  { key: 'matricula', label: 'matricula' },
+  { key: 'cargo', label: 'cargo' },
+  { key: 'departamento', label: 'departamento' },
+  { key: 'salario_base', label: 'salario_base' },
+  { key: 'comissao', label: 'comissao' },
+  { key: 'dsr', label: 'dsr' },
+  { key: 'dias_dsr', label: 'dias_dsr' },
+  { key: 'valor_bruto', label: 'valor_bruto' },
+  { key: 'valor_liquido', label: 'valor_liquido' },
+  { key: 'data_pagamento', label: 'data_pagamento' },
+  { key: 'user_email', label: 'user_email' },
+  { key: 'fonte_arquivo', label: 'fonte_arquivo' },
+  { key: 'holerite_id', label: 'holerite_id' },
+  { key: 'rubricas_json', label: 'rubricas_json', textarea: true },
+  { key: 'status_validacao', label: 'status_validacao' },
+  { key: 'total_proventos', label: 'total_proventos' },
+  { key: 'total_descontos', label: 'total_descontos' },
+  { key: 'base_inss', label: 'base_inss' },
+  { key: 'base_fgts', label: 'base_fgts' },
+  { key: 'base_irrf', label: 'base_irrf' },
+  { key: 'fgts_mes', label: 'fgts_mes' },
+];
+
+export default function HoleriteReviewDialog({ open, onOpenChange, itemIndex, totalItems, pdfFile, extracted, candidates, onSave, onPrev, onNext }: Props) {
+  const [data, setData] = useState<HoleriteDraft>(extracted);
+  const [pdfUrl, setPdfUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    setData(extracted);
+  }, [extracted]);
+
+  useEffect(() => {
+    if (pdfFile) {
+      const url = URL.createObjectURL(pdfFile);
+      setPdfUrl(url);
+      return () => URL.revokeObjectURL(url);
+    }
+  }, [pdfFile]);
+
+  if (!open) return null;
+
+  const handleChange = (key: keyof HoleriteDraft, value: string) => {
+    setData(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleSave = async () => {
+    await onSave(data);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-2xl shadow-md w-11/12 h-5/6 p-4 flex flex-col">
+        <div className="flex-1 flex overflow-hidden">
+          <div className="w-1/2 pr-2 h-full overflow-auto bg-gray-50 flex items-center justify-center">
+            {pdfUrl ? (
+              <embed src={pdfUrl} className="w-full h-full" />
+            ) : (
+              <div className="text-sm text-gray-500">Sem preview</div>
+            )}
+          </div>
+          <div className="w-1/2 pl-2 h-full overflow-auto">
+            {FIELDS.map(f => (
+              <div key={f.key as string} className="mb-3">
+                <label className="block text-sm font-medium mb-1">{f.label}</label>
+                {f.textarea ? (
+                  <textarea
+                    value={data[f.key] || ''}
+                    onChange={e => handleChange(f.key, e.target.value)}
+                    className="w-full border rounded p-2 text-sm"
+                    rows={4}
+                  />
+                ) : (
+                  <input
+                    value={data[f.key] || ''}
+                    onChange={e => handleChange(f.key, e.target.value)}
+                    className="w-full border rounded p-2 text-sm"
+                  />
+                )}
+                {candidates && candidates[f.key] && (
+                  <select
+                    onChange={e => handleChange(f.key, e.target.value)}
+                    className="mt-1 w-full border rounded p-1 text-sm"
+                    value={data[f.key] || ''}
+                  >
+                    <option value="">--Selecionar--</option>
+                    {candidates[f.key]!.map(c => (
+                      <option key={String(c)} value={String(c)}>{String(c)}</option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="pt-4 flex justify-between items-center">
+          <button className="px-4 py-2 rounded-md bg-gray-200" onClick={() => onOpenChange(false)}>Cancelar</button>
+          <div className="space-x-2">
+            <button className="px-4 py-2 rounded-md bg-gray-200" disabled={itemIndex===0} onClick={onPrev}>Anterior</button>
+            <button className="px-4 py-2 rounded-md bg-gray-200" disabled={itemIndex>=totalItems-1} onClick={onNext}>Próximo</button>
+            <button className="px-4 py-2 rounded-md bg-blue-600 text-white" onClick={handleSave}>Salvar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/importHolerites.ts
+++ b/lib/importHolerites.ts
@@ -29,7 +29,9 @@ function monthNameToNumber(name: string): string | null {
   return map[name] || null;
 }
 
-function extractFields(text: string, options: {userEmail?: string, dataPagamentoDefault?: string, fonte: string}): HoleriteRow {
+// Exported for reuse by API routes that need to parse holerites without immediately
+// writing to Google Sheets.
+export function extractFields(text: string, options: {userEmail?: string, dataPagamentoDefault?: string, fonte: string}): HoleriteRow {
   const empresa = matchLine(text, /empresa[:\s]*([\w .-]+)/i);
   const cnpj = formatCnpj(matchLine(text, /cnpj[:\s]*([0-9\.\/-]+)/i));
   const colaborador = matchLine(text, /(colaborador|empregado|funcion\w+)[:\s]*([\w .-]+)/i,2);


### PR DESCRIPTION
## Summary
- add holerite import and save API routes
- introduce client dialog to review holerite data before persisting
- allow uploading PDFs from home page and persist parsed data to Google Sheets

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: no output / network issue)*

------
https://chatgpt.com/codex/tasks/task_e_68b21b64c780832c9923691232a298e5